### PR TITLE
Add Keyboard Shortcuts for Timer Functions and Timer Update in Browser Tab Title

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>PTime PWA</title>
+  <title>PTime</title>
   <meta name="description" content="Ptime - A simple and efficient timer application with offline support." />
   <meta name="keywords" content="timer, countdown, stopwatch, PWA, offline" />
 

--- a/src/main.js
+++ b/src/main.js
@@ -71,6 +71,7 @@ function formatTime(unit) {
 
 function updateTimerDisplay() {
     const timerState = getCurrentState();
+    const isRunning = isTimerRunning();
 
     const formattedHours = formatTime(timerState.hours);
     const formattedMinutes = formatTime(timerState.minutes);
@@ -79,14 +80,28 @@ function updateTimerDisplay() {
     const formattedTime = `${formattedHours}:${formattedMinutes}:${formattedSeconds}`;
     timerDisplay.textContent = formattedTime;
 
+    const baseTitle = "PTime";
+    let newDocumentTitle = "";
+
+    if (isRunning) {
+        newDocumentTitle = `${formattedTime} - ${baseTitle}`;
+    } else {
+        if (timerState.pausedElapsed > 0 && !(timerState.hours === 0 && timerState.minutes === 0 && timerState.seconds === 0)) {
+            newDocumentTitle = `Paused | ${formattedTime} - ${baseTitle}`;
+        } else {
+            if (timerState.hours === 0 && timerState.minutes === 0 && timerState.seconds === 0) {
+                newDocumentTitle = baseTitle;
+            } else {
+                newDocumentTitle = `${formattedTime} - ${baseTitle}`;
+            }
+        }
+    }
+    document.title = newDocumentTitle;
 }
 
-// Replace your existing toggleFullscreen function with this:
 function toggleFullscreen() {
-    // Get the document element
     const doc = document.documentElement;
     
-    // Check if currently in fullscreen
     const isFullscreen = 
         document.fullscreenElement || 
         document.webkitFullscreenElement || 
@@ -174,6 +189,67 @@ editInputs.forEach(input => {
             input.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }, 300); // Wait for keyboard animation
     });
+});
+
+//KEYBOARD SHORTCUTS
+window.addEventListener('keydown', (event) => {
+    const activeElement = document.activeElement;
+    const isInputFocused = activeElement && (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA');
+
+    if (!editContainer.classList.contains('hidden')) {
+        if (event.key === 'Enter') {
+            if (isInputFocused && (activeElement === editHoursInput || activeElement === editMinutesInput || activeElement === editSecondsInput)) {
+                event.preventDefault();
+                saveButton.click();
+            } else if (activeElement === saveButton) {
+                event.preventDefault();
+                saveButton.click();
+            }
+            return; 
+        } else if (event.key === 'Escape') {
+            event.preventDefault();
+            backFromEditButton.click(); 
+            return; 
+        }
+
+        if (isInputFocused) {
+            return;
+        }
+    }
+
+    switch (event.key.toLowerCase()) {
+        case 'e': 
+            event.preventDefault();
+            if (editContainer.classList.contains('hidden')) {
+                editButton.click();
+            } else {
+                backFromEditButton.click();
+            }
+            break;
+
+        case 's':
+            if (editContainer.classList.contains('hidden')) {
+                event.preventDefault();
+                if (!isTimerRunning()) { 
+                    toggleButton.click(); 
+                }
+            }
+            break;
+        case 'p':
+            if (editContainer.classList.contains('hidden')) {
+                event.preventDefault();
+                if (isTimerRunning()) { 
+                    toggleButton.click(); 
+                }
+            }
+            break;
+        case 'r':
+            if (editContainer.classList.contains('hidden')) {
+                event.preventDefault();
+                resetButton.click();
+            }
+            break;
+    }
 });
 
 window.addEventListener("load", () => {


### PR DESCRIPTION
This PR introduces two enhancements to improve user experience and accessibility:

**1. Keyboard Shortcuts:**
   - Users can now control core timer functions using keyboard shortcuts:
     - `s` - Start Timer
     - `p` - Pause Timer
     - `r` - Reset Timer
     - `e` - Toggle Edit Menu (Open/Close)
   - When the Edit Menu is open:
     - `Enter` (while an input or Save button is focused) - Save changes
     - `Escape` - Close Edit Menu
   - Shortcuts are disabled when input fields are focused to prevent conflicts.

**2. Dynamic Browser Tab Title:**
   - The browser tab title now dynamically updates to reflect the current state of the timer:
     - Displays the running time (e.g., "00:15:30 - PTime")
     - Indicates when paused (e.g., "Paused | 00:10:05 - PTime")
     - Shows the base title when the timer is reset or at its initial state (e.g., "PTime")